### PR TITLE
Fixed pandas scatter matrix call

### DIFF
--- a/notebooks/03 Data Representation for Machine Learning.ipynb
+++ b/notebooks/03 Data Representation for Machine Learning.ipynb
@@ -412,7 +412,7 @@
     "import pandas as pd\n",
     "    \n",
     "iris_df = pd.DataFrame(iris.data, columns=iris.feature_names)\n",
-    "pd.tools.plotting.scatter_matrix(iris_df, figsize=(8, 8));"
+    "pd.plotting.scatter_matrix(iris_df, figsize=(8, 8));"
    ]
   },
   {


### PR DESCRIPTION
Previously this line would throw:
`AttributeError: module 'pandas' has no attribute 'tools'.`
Removing `tools.` fixes this.